### PR TITLE
examples: Fixed two-window bug

### DIFF
--- a/examples/testview.py
+++ b/examples/testview.py
@@ -363,6 +363,6 @@ class GFreenectView(Gtk.Window):
         Gtk.main_quit()
 
 if __name__ == '__main__':
-    Clutter.init(sys.argv)
+    GtkClutter.init(sys.argv)
     view = GFreenectView()
     Gtk.main()


### PR DESCRIPTION
Fixed two-window bug in testview.py example with the solution found in https://bugs.launchpad.net/ubuntu/+source/clutter-1.0/+bug/956146
